### PR TITLE
Allow users to remove destinations from their list

### DIFF
--- a/templates/announcements/destination_admin_confirm_delete.html
+++ b/templates/announcements/destination_admin_confirm_delete.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% block title %}Remove Self from Destination{% endblock %}
+{% block content_title %}Remove Self from Destination{% endblock %}
+{% block content %}
+  {% if admins %}
+    <p>You are removing yourself as an admin of {{ destination.subclass.name }}.
+    There are still other admins configured, so no other changes will be made
+    to the destination. (If it is configured to receive any announcements, it
+    will continue to do so.)</p>
+    <p>After you take this action, the following users will administer this
+    destination:</p>
+    <ul>
+      {% for admin in admins %}
+        <li>{{ admin.get_full_name }} ({{ admin.username }})</li>
+      {% endfor %}
+    </ul>
+    <p>You will be able to ask any one of those users, or use the "Connect"
+    workflow again, if you need to be added back to this destination.</p>
+  {% else %}
+    <p>You are removing yourself as an admin of {{ destination.subclass.name }}.
+    There are no other admins configured, so this action will also delete this
+    destination from the system. (It will not continue to receive any
+    announcements.)</p>
+    <p>If you want to add it again in the future, you will have to use the
+    "Connect" workflow again.</p>
+  {% endif %}
+  <p><em>Are you sure you want to do this?</em><p>
+  <form action="" method="post">{% csrf_token %}
+    <input type="submit" class="btn btn-danger" value="Yes, Remove Me">
+    <a href="{% url 'destination_list' %}" class="btn btn-primary" role="button">No, Go Back</a>
+  </form>
+{% endblock %}
+

--- a/templates/announcements/destination_list.html
+++ b/templates/announcements/destination_list.html
@@ -13,7 +13,10 @@
     {% for obj in object_list %}{% with obj.subclass as destination %}
       <tr>
         <td><a href="{{ destination.get_absolute_url }}">{{ destination.subclass.name }}</a></td>
-        <td>{% for user in destination.admins.all %}{{ user.get_full_name }} ({{ user.username }}){% if not forloop.last %}<br>{% endif %}{% endfor %}</td>
+        <td>
+          {% for user in destination.admins.all %}{{ user.get_full_name }} ({{ user.username }}){% if not forloop.last %}<br>{% endif %}{% endfor %}<br>
+          <a href="{% url 'destination_remove_admin' destination.id %}" class="btn btn-danger" role="button">Remove Me</a>
+        </td>
         <td>{% for obj in destination.message_types.all %}{% with obj.subclass as message_source %}
           {{ message_source.name }}{% if not forloop.last %}<br>{% endif %}
         {% endwith %}{% endfor %}</td>

--- a/urls.py
+++ b/urls.py
@@ -49,6 +49,8 @@ urlpatterns = [
          name='destination_list'),
     path('destinations/detail/<int:pk>/', views.DestinationDetail.as_view(),
          name='destination_detail'),
+    path('destinations/<int:pk>/remove/', views.DestinationRemoveAdmin.as_view(),
+         name='destination_remove_admin'),
 
     path('announcements/create/',
          views.CreateAnnouncementView.as_view(),


### PR DESCRIPTION
This patch allows users to remove themselves from a destination,
thereby removing it from their list of destinations, in the case of
testing channels or mistakes. This also removes all notifications to
that destination when the last admin is removed, to avoid the case
where there is no one left to configure a destination.

Resolves #36