### PR TITLE
Fix Blog announcement headline <-> blog name swap

### DIFF
--- a/announcements/models.py
+++ b/announcements/models.py
@@ -544,7 +544,7 @@ class Announcement(CreatedUpdatedMixin, models.Model):
 
     @property
     def truncated_text(self):
-        text = Truncator(self.text).words(25, html=True)
+        text = Truncator(self.text).words(50, html=True)
         text = ">" + text
         text = re.sub("\n", "\n>", text)
         return text
@@ -710,7 +710,7 @@ class BlogAnnouncement(Announcement):
             'type': 'section',
             'text': {
                 'type': 'mrkdwn',
-                'text': f"*{source.name} - New Blog Post in {self.headline}*",
+                'text': f"*{self.headline} - New Blog Post in {source.name}*",
             },
         })
         data.append({


### PR DESCRIPTION
These were accidentally reversed, see #60